### PR TITLE
Update resque-scheduler to use Composer auto-loader

### DIFF
--- a/README.md
+++ b/README.md
@@ -408,8 +408,8 @@ worker is responsible for pulling items off the schedule/delayed queue and addin
 them to the queue for resque. This means that for delayed or scheduled jobs to be
 executed, that worker needs to be running.
 
-A basic "up-and-running" `resque-scheduler.php` file that sets up a
-running worker environment is included (`vendor/resque-scheduler.php` when
+A basic "up-and-running" `bin/resque-scheduler` file that sets up a
+running worker environment is included (`vendor/bin/resque-scheduler` when
 installed via composer). It accepts many of the same environment variables as
 the main workers for php-resque:
 
@@ -421,14 +421,8 @@ the main workers for php-resque:
 * `APP_INCLUDE` - Include this file when starting (to launch your app)
 * `PIDFILE` - Write the PID of the worker out to this file
 
-The resque-scheduler worker requires resque to function. The demo
-resque-scheduler.php worker allows you to supply a `RESQUE_PHP` environment
-variable with the path to Resque.php. If not supplied and resque is not already
-loaded, resque-scheduler will attempt to load it from your include path
-(`require_once 'Resque/Resque.php';'`)
-
-It's easy to start the resque-scheduler worker using resque-scheduler.php:
-    $ RESQUE_PHP=./lib/Resque/Resque.php php resque-scheduler.php
+It's easy to start the resque-scheduler worker using bin/resque-scheduler:
+    $ RESQUE_PHP=./lib/Resque/Resque.php php bin/resque-scheduler
 
 ## Event/Hook System
 

--- a/bin/autoload.php
+++ b/bin/autoload.php
@@ -1,0 +1,25 @@
+<?php
+
+// Find and initialize Composer
+$files = array(
+  __DIR__ . '/../../vendor/autoload.php',
+  __DIR__ . '/../../../autoload.php',
+  __DIR__ . '/../../../../autoload.php',
+  __DIR__ . '/../vendor/autoload.php',
+);
+
+$found = false;
+foreach ($files as $file) {
+  if (file_exists($file)) {
+    require_once $file;
+    break;
+  }
+}
+
+if (!class_exists('Composer\Autoload\ClassLoader', false)) {
+  die(
+    'You need to set up the project dependencies using the following commands:' . PHP_EOL .
+    'curl -s http://getcomposer.org/installer | php' . PHP_EOL .
+    'php composer.phar install' . PHP_EOL
+  );
+}

--- a/bin/resque
+++ b/bin/resque
@@ -1,29 +1,8 @@
 #!/usr/bin/env php
 <?php
 
-// Find and initialize Composer
-$files = array(
-    __DIR__ . '/../../vendor/autoload.php',
-    __DIR__ . '/../../../autoload.php',
-    __DIR__ . '/../../../../autoload.php',
-    __DIR__ . '/../vendor/autoload.php',
-);
-
-$found = false;
-foreach ($files as $file) {
-    if (file_exists($file)) {
-        require_once $file;
-        break;
-    }
-}
-
-if (!class_exists('Composer\Autoload\ClassLoader', false)) {
-    die(
-        'You need to set up the project dependencies using the following commands:' . PHP_EOL .
-            'curl -s http://getcomposer.org/installer | php' . PHP_EOL .
-            'php composer.phar install' . PHP_EOL
-    );
-}
+// Initialize Composer autoloader.
+require_once __DIR__ . '/autoload.php';
 
 $QUEUE = getenv('QUEUE');
 if(empty($QUEUE)) {

--- a/bin/resque-scheduler
+++ b/bin/resque-scheduler
@@ -1,18 +1,8 @@
+#!/usr/bin/env php
 <?php
 
-// Look for an environment variable with 
-$RESQUE_PHP = getenv('RESQUE_PHP');
-if (!empty($RESQUE_PHP)) {
-	require_once $RESQUE_PHP;
-}
-// Otherwise, if we have no Resque then assume it is in the include path
-else if (!class_exists('Resque')) {
-	require_once 'Resque/Resque.php';
-}
-
-// Load resque-scheduler
-require_once dirname(__FILE__) . '/lib/ResqueScheduler.php';
-require_once dirname(__FILE__) . '/lib/ResqueScheduler/Worker.php';
+// Initialize Composer autoloader.
+require_once __DIR__ . '/autoload.php';
 
 $REDIS_BACKEND = getenv('REDIS_BACKEND');
 $REDIS_BACKEND_DB = getenv('REDIS_BACKEND_DB');

--- a/composer.json
+++ b/composer.json
@@ -41,7 +41,8 @@
 		"phpunit/phpunit": "3.7.*"
 	},
 	"bin": [
-		"bin/resque"
+		"bin/resque",
+		"bin/resque-scheduler"
 	],
 	"autoload": {
 		"psr-0": {


### PR DESCRIPTION
Regarding https://github.com/resque/php-resque/pull/19:
Here the changes to address review comments form PR.

Used Composer autoloader, resque-scheduler.php script moved to the bin directory, added related changes into composer.json file.